### PR TITLE
changes around NATS client api

### DIFF
--- a/nhgc/examples/nats.ts
+++ b/nhgc/examples/nats.ts
@@ -1,0 +1,94 @@
+import { newNHG } from "../mod.ts";
+import { getConnectionDetails } from "../credentials.ts";
+
+// create the gateway client
+const nhg = newNHG(getConnectionDetails());
+
+const nc = nhg.nats;
+
+// to receive messages you can create a subscription.
+// subscriptions are backed by an EventSource (SSE)":
+let count = 0;
+const sub = await nc.subscribe("hello", (err, msg) => {
+  if (err) {
+    console.error(err.message);
+    return;
+  }
+  if (msg) {
+    count++;
+    // print a message
+    console.log(
+      `[${count}]: msg with payload "${msg.string()}" which has ${
+        msg.data?.length || 0
+      } bytes`,
+    );
+    // print the headers
+    console.log("\t", msg.headers);
+
+    // if you think the data is JSON, you can use:
+    // msg.json() to decode it.
+  }
+});
+
+// you can publish an empty message
+await nc.publish("hello");
+
+// you can specify a payload - payload can be a string, an Uint8Array or a ReadableStream<Uint8Array>
+await nc.publish("hello", "world");
+
+// you can also specify headers that will be included on the message.
+// the only restriction is that the header keys must begin with the prefix `NatsH-`.
+// Note that the prefix will be stripped. So for `NatsH-Hello` the NATS message
+// will have a `Hello` header.
+await nc.publish("hello", "world", {
+  headers: {
+    "NatsH-Language": "EN",
+  },
+});
+
+// Implementing a service is simply a subscription that replies
+const svc = await nc.subscribe("q", async (err, msg) => {
+  if (err) {
+    console.error(err.message);
+    return;
+  }
+  if (msg?.reply) {
+    // echo the request - we are going to echo all the headers back and because
+    // we are using the gateway, we need to transform them:
+    const headers = new Headers();
+    msg.headers.forEach((v, k) => {
+      headers.append(`NatsH-${k}`, v);
+    });
+    await nc.publish(msg.reply, msg.data, { headers });
+  } else {
+    console.log("message doesn't have a reply - ignoring");
+  }
+});
+
+// to trigger a request:
+const r = await nc.request("q", "question", {
+  headers: {
+    "NatsH-My-Header": "Hi",
+  },
+});
+console.log(
+  `got a response with payload "${r.string()}" which has ${
+    r.data?.length || 0
+  } bytes\n\t`,
+  r.headers,
+);
+
+// now - it is also publish a request, that redirects to a different
+// subscription - this is only used on advanced usages, but shows that
+// you can delegate someone else to process your message.
+
+await nc.publishWithReply("q", "hello", "question2", {
+  headers: {
+    "NatsH-My-Header": "Hi",
+  },
+});
+
+await nc.flush();
+
+sub.unsubscribe();
+svc.unsubscribe();

--- a/nhgc/kv.ts
+++ b/nhgc/kv.ts
@@ -26,7 +26,7 @@ import {
   Watcher,
 } from "./types.ts";
 import { HttpImpl } from "./nhgc.ts";
-import { Deferred, deferred } from "./util.ts";
+import { addEventSource, Deferred, deferred } from "./util.ts";
 
 type KvE = {
   bucket: string;
@@ -272,9 +272,10 @@ export class KvImpl extends HttpImpl implements Kv {
       ? `/v1/kvm/buckets/${this.bucket}/watch?${qs}`
       : `/v1/kvm/buckets/${this.bucket}/watch`;
 
-    return Promise.resolve(
-      new KvWatcher(new EventSource(new URL(path, this.url)), opts.callback),
-    );
+    return addEventSource(new URL(path, this.url))
+      .then((es) => {
+        return new KvWatcher(es, opts.callback);
+      });
   }
 
   async info(): Promise<KvBucketInfo> {

--- a/nhgc/util.ts
+++ b/nhgc/util.ts
@@ -37,3 +37,20 @@ export function deferred<T>(): Deferred<T> {
   });
   return Object.assign(p, methods) as Deferred<T>;
 }
+
+export function addEventSource(
+  url: string | URL,
+  eventSourceInitDict?: EventSourceInit,
+): Promise<EventSource> {
+  const d = deferred<EventSource>();
+  const es = new EventSource(url, eventSourceInitDict);
+  es.addEventListener("open", () => {
+    d.resolve(es);
+  });
+
+  es.addEventListener("error", () => {
+    d.reject(new Error("error creating the EventSource"));
+  });
+
+  return d;
+}


### PR DESCRIPTION
- [FEAT] nats examples
- [FIX] internal EventSource creation now checks for errors from the event source on creation. 
- [CHANGE] added support for publish/request with headers and made nats headers by a HeadersInit to allow for standard header types
-  [FIX] added a `flush()` to help tests - need to implement that on the gateway normally.