### PR TITLE
feat(fastingest): new module for jetstream fast-ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: f
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.6.x
+          deno-version: 2.7.x
+
+      - name: install nats-server
+        if: matrix.module == 'fastingest'
+        uses: aricart/install-binary@v2.0.0
+        with:
+          repo: nats-io/nats-server
+          name: nats-server
 
       - name: lint
         working-directory: ${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
             counters: counters/**
             messagepipeline: messagepipeline/**
             muxsub: muxsub/**
+            fastingest: fastingest/**
 
   test:
     needs: detect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,12 @@ jobs:
       - uses: denoland/setup-deno@v2
         if: steps.ctx.outputs.has_jsr == 'true'
         with:
-          deno-version: 2.6.x
+          deno-version: 2.7.x
 
       - uses: actions/setup-node@v6
         if: steps.ctx.outputs.has_npm == 'true'
         with:
-          node-version: 24.x
+          node-version: 25.x
           registry-url: "https://registry.npmjs.org"
 
       - name: jsr test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
           - messagepipeline
           - muxsub
           - nhgc
+          - fastingest
       version:
         required: true
         description: "version (no v prefix), e.g. 1.2.3"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ This is a list of the current utilities hosted here
 | MuxSub          | A NATS multiplexing subscription utility      | [README.md](muxsub/README.md)          |
 | MessagePipeline | Middleware transformations for NATS messages  | [README.md](messagepipeline/README.md) |
 | Counters        | JetStream-based atomic counter implementation | [README.md](counters/README.md)        |
+| FastIngest      | JetStream fast-ingest batch publish API       | [README.md](fastingest/README.md)      |

--- a/counters/package-lock.json
+++ b/counters/package-lock.json
@@ -13,9 +13,9 @@
         "@nats-io/nats-core": "3.3.1"
       },
       "devDependencies": {
-        "@types/node": "^24.5.0",
+        "@types/node": "^25.6.2",
         "shx": "^0.4.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@nats-io/jetstream": {
@@ -97,13 +97,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/braces": {
@@ -275,13 +275,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/counters/package.json
+++ b/counters/package.json
@@ -36,7 +36,7 @@
     "@nats-io/jetstream": "3.3.1"
   },
   "devDependencies": {
-    "@types/node": "^24.12.2",
+    "@types/node": "^25.6.2",
     "shx": "^0.4.0",
     "typescript": "^5.9.3"
   }

--- a/fastingest/LICENSE
+++ b/fastingest/LICENSE
@@ -1,0 +1,196 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (which shall not include communications that are submitted to
+      Licensor for purposes of discussing and improving the Work, but
+      excluding communications that are marked or otherwise
+      designated in writing by the Licensor as "Not a Contribution.")
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control
+      systems, and issue tracking systems that are managed by, or on behalf
+      of, the Licensor for the purpose of discussing and improving the Work,
+      but excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, modify, merge, publish,
+      distribute, sublicense, and/or sell copies of the Work, and to
+      permit persons to whom the Work is furnished to do so, subject to
+      the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Work.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, trademark, patent,
+          attribution and other notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice within Derivative Works that
+      You distribute, alongside or as an addendum to the NOTICE text from
+      the Work, provided that such additional copyright notice cannot be
+      construed as modifying the License.
+
+      You may add Your own license terms to Your use, reproduction, and
+      distribution of the Work or Derivative Works thereof, provided that
+      Your use, reproduction, and distribution of the Work otherwise
+      complies with the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. You may choose to offer, and to
+      charge a fee for, warranty, support, indemnity or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and on
+      Your sole responsibility, not on behalf of any other Contributor, and
+      only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/fastingest/README.md
+++ b/fastingest/README.md
@@ -1,0 +1,50 @@
+# fastingest
+
+Re-export of the JetStream fast-ingest batch publish API from
+`@nats-io/jetstream`. Provides `startFastIngest()` and related types as a stable
+orbit surface while the API remains in the jetstream module's internal export.
+
+Fast-ingest trades atomicity for throughput: messages may be dropped, and the
+server reports gaps via `FastIngestProgress`. Requires NATS server 2.14.0+ and a
+stream created with `allow_batched: true`.
+
+## Install
+
+```bash
+npm install @synadiaorbit/fastingest
+```
+
+```bash
+deno add jsr:@synadiaorbit/fastingest
+```
+
+## Usage
+
+```ts
+import { wsconnect } from "@nats-io/nats-core";
+import { jetstreamManager } from "@nats-io/jetstream";
+import { startFastIngest } from "@synadiaorbit/fastingest";
+
+const nc = await wsconnect({ servers: "wss://demo.nats.io:8443" });
+
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "batch",
+  subjects: ["q"],
+  allow_batched: true,
+});
+
+const fi = await startFastIngest(nc, "q", "1", {
+  allowGaps: false,
+  ackInterval: 5,
+});
+await fi.add("q", "2");
+await fi.add("q", "3");
+const ack = await fi.last("q", "4");
+console.log(ack.count, ack.seq);
+
+await nc.close();
+```
+
+See `@nats-io/jetstream` source for `FastIngest`, `FastIngestOptions`, and
+`FastIngestProgress` shapes.

--- a/fastingest/README.md
+++ b/fastingest/README.md
@@ -1,12 +1,102 @@
 # fastingest
 
-Re-export of the JetStream fast-ingest batch publish API from
-`@nats-io/jetstream`. Provides `startFastIngest()` and related types as a stable
-orbit surface while the API remains in the jetstream module's internal export.
+High-throughput batch publish to NATS JetStream. Re-exports the fast-ingest API
+from `@nats-io/jetstream/internal` as a stable orbit surface while the upstream
+API is still considered internal.
 
-Fast-ingest trades atomicity for throughput: messages may be dropped, and the
-server reports gaps via `FastIngestProgress`. Requires NATS server 2.14.0+ and a
-stream created with `allow_batched: true`.
+> Status: incubating. The underlying protocol is stable; the client API shape is
+> still being explored. Once it settles upstream, this module becomes a thin
+> shim or retires.
+
+## Why
+
+JetStream's regular publish waits for an ack on every message. The async form
+overlaps in-flight publishes via `Promise.all([...])`, which doesn't raise the
+sustainable rate — each publish still pays its round-trip — but removes the
+shared brake: under concurrent producers some publishes fail and the client has
+to guess at concurrency limits and retry.
+
+Fast-ingest is the purpose-built alternative (specified in
+[ADR-50](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-50.md)).
+The client opens a batch and streams messages into it. The server acks the batch
+periodically, not per-message, and **decides the pace** based on how busy the
+stream is — speeding the client up when there's headroom, slowing it down when
+there isn't.
+
+The client sets two ceilings:
+
+- **`ackInterval`** — the most messages the client wants the server to go
+  between acks (bigger window = faster).
+- **`maxOutstandingAcks`** — the most unacked windows the client allows before
+  pausing (1–3, default 2).
+
+Everything else is invisible. The library tracks the server's current cadence
+and resizes the publish window for you. The application's only job is to **await
+each `fi.add(...)`** — the promise resolves when the window has room and stalls
+when it doesn't, so honoring it gives the producer the correct rate
+automatically.
+
+> **Don't fan out with `Promise.all([...])`.** Concurrent adds don't beat the
+> rate — each call still waits its slot — and they defeat back-pressure, piling
+> pending publishes in the caller for no throughput gain. Drive the loop in
+> lockstep: await each `add()` before queuing more.
+
+Result: many producers can push the same stream concurrently without overload,
+and other JetStream operations on the stream (purge, delete, config change) stay
+responsive.
+
+The batch ends when the client calls `last()` (commit + store the final message)
+or `end()` (commit, no final message).
+
+### Gaps
+
+Messages are stored as the server receives them — there is no rollback. The
+caller chooses what happens if the server detects a gap in the batch sequence:
+
+- `allowGaps: false` — server aborts the batch on the first gap. Messages before
+  the gap stay stored. The caller can open a new batch and resume from the gap
+  sequence.
+- `allowGaps: true` — gaps are reported via `gaps()`; the batch keeps accepting
+  new messages.
+
+### When to reach for it
+
+ADR-50 motivates fast-ingest as the replacement for async publish in
+high-throughput producers, and calls out two concrete shapes:
+
+- **Object Store writes**, where every chunk must land or the file is corrupt —
+  use `allowGaps: false` so the server aborts on any gap and the caller can
+  restart from the gap sequence. `@nats-io/obj` has an undocumented
+  `allowBatched: true` opt-in on `os.create()`/`os.open()` that routes chunk
+  writes through fast-ingest with no other code changes — a quick way to try it
+  on a real workload.
+- **Fast metric publishers**, where occasional drops are acceptable — use
+  `allowGaps: true` so the batch keeps moving and gaps are surfaced via `gaps()`
+  for observability.
+
+If a producer doesn't need that throughput tier, regular `js.publish()` remains
+the right tool — fast-ingest is the bulk-ingest path, not a general publish
+replacement.
+
+## Server requirement
+
+NATS server **2.14.0** or later. Older servers reject the `allow_batched` stream
+config field.
+
+## Stream requirement
+
+The target stream must be created with `allow_batched: true`. Existing streams
+must be updated to opt-in.
+
+```ts
+await jsm.streams.add({
+  name: "orders",
+  subjects: ["orders.>"],
+  allow_batched: true,
+});
+```
+
+`startFastIngest` rejects against a non-batched stream.
 
 ## Install
 
@@ -18,33 +108,155 @@ npm install @synadiaorbit/fastingest
 deno add jsr:@synadiaorbit/fastingest
 ```
 
-## Usage
+Peer requirement: `@nats-io/jetstream` and `@nats-io/nats-core` at `3.4.x` or
+later.
+
+## API
+
+### Creating a batch
 
 ```ts
-import { wsconnect } from "@nats-io/nats-core";
+function startFastIngest(
+  nc: NatsConnection,
+  subj: string, // first message subject
+  payload?: Payload, // first message payload
+  opts: {
+    allowGaps: boolean;
+    ackInterval?: number;
+    maxOutstandingAcks?: number;
+    inboxPrefix?: string;
+  } & Partial<JetStreamPublishOptions>,
+): Promise<FastIngest>;
+```
+
+`startFastIngest` publishes the first message of the batch and waits for the
+server's initial flow-control ack. The fourth argument requires `allowGaps` and
+accepts the rest of `FastIngestOptions` plus any `JetStreamPublishOptions`
+(headers, `msgID`, expectations, etc.):
+
+| option                   | meaning                                                                                                                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`allowGaps`**          | Required. `false` → first gap aborts the batch. `true` → gaps reported via `gaps()`, batch keeps accepting messages.                                                                          |
+| **`ackInterval`**        | Maximum messages the client lets the server go between acks. Higher = faster (longer publish window per ack). Server picks anywhere from `1` up to this max based on stream load. Default 10. |
+| **`maxOutstandingAcks`** | How many ack windows the client lets sit unacked before pausing. Effective in-flight messages = `ackInterval * maxOutstandingAcks`. Default 2; values outside 1–3 are clamped.                |
+| **`inboxPrefix`**        | Subject prefix for the batch's reply inbox. Default `_INBOX`.                                                                                                                                 |
+
+```ts
+const fi = await startFastIngest(nc, "orders.created", firstOrder, {
+  allowGaps: false,
+  ackInterval: 100,
+});
+```
+
+Use the returned `FastIngest` to publish the rest and terminate.
+
+### The FastIngest batch
+
+```ts
+type FastIngest = {
+  readonly batch: string;
+  add(
+    subj: string,
+    payload?: Payload,
+    opts?: Partial<JetStreamPublishOptions>,
+  ): Promise<FastIngestProgress>;
+  last(
+    subj: string,
+    payload?: Payload,
+    opts?: Partial<JetStreamPublishOptions>,
+  ): Promise<BatchAck>;
+  end(opts?: Partial<JetStreamPublishOptions>): Promise<BatchAck>;
+  ping(timeout?: number): Promise<FastIngestProgress>;
+  done(): Promise<BatchAck>;
+  gaps(): AsyncIterable<{ lastSeq: number; seq: number }>;
+};
+```
+
+- `batch` — the batch's unique id, generated by `startFastIngest`. Matches
+  `BatchAck.batch` on the terminal ack.
+- `add()` — publish a body message. Returns `FastIngestProgress` =
+  `{ batchSeq, ackSeq }`, where `batchSeq` is this message's 1-based position in
+  the batch (not its stream sequence) and `ackSeq` is the highest position the
+  server has acked so far. The promise resolves only when the in-flight window
+  has room — see [Why](#why).
+- `last()` / `end()` — terminate the batch. Both resolve to a `BatchAck`
+  containing the last stored stream sequence (`seq`) and the count of messages
+  stored (`count`). `last()` stores the supplied final message; `end()` commits
+  with no extra message.
+- `ping()` — keep-alive. Returns a fresh `FastIngestProgress` direct from the
+  server (vs `add()` which returns the client's cached view). Use when the
+  producer might pause longer than the 10-second idle limit.
+- `done()` — resolves with the terminal `BatchAck` regardless of how the batch
+  ended; useful when the lifecycle is driven elsewhere.
+- `gaps()` — async iterable yielding `{ lastSeq, seq }` for each missing range
+  the server detected. Both fields are batch sequences. With `allowGaps: false`
+  the server also aborts the batch on the first gap; with `allowGaps: true` it
+  continues.
+
+## Usage
+
+The example below assumes you already have a `NatsConnection`. Pick whichever
+transport fits your runtime — `@nats-io/transport-node`,
+`@nats-io/transport-deno`, or `wsconnect` from `@nats-io/nats-core` for
+browsers.
+
+```ts
+import type { NatsConnection } from "@nats-io/nats-core";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { startFastIngest } from "@synadiaorbit/fastingest";
 
-const nc = await wsconnect({ servers: "wss://demo.nats.io:8443" });
+declare const nc: NatsConnection;
 
 const jsm = await jetstreamManager(nc);
 await jsm.streams.add({
-  name: "batch",
-  subjects: ["q"],
+  name: "orders",
+  subjects: ["orders.>"],
   allow_batched: true,
 });
 
-const fi = await startFastIngest(nc, "q", "1", {
-  allowGaps: false,
-  ackInterval: 5,
-});
-await fi.add("q", "2");
-await fi.add("q", "3");
-const ack = await fi.last("q", "4");
-console.log(ack.count, ack.seq);
+declare const orders: string[]; // serialized order events to replay
 
-await nc.close();
+const fi = await startFastIngest(nc, "orders.created", orders[0], {
+  allowGaps: false,
+  ackInterval: 100,
+});
+
+for (let i = 1; i < orders.length - 1; i++) {
+  await fi.add("orders.created", orders[i]);
+}
+
+// terminate with a final message — use `fi.end()` to commit without one
+const ack = await fi.last("orders.created", orders[orders.length - 1]);
+console.log(`stored ${ack.count} messages, last seq ${ack.seq}`);
 ```
 
-See `@nats-io/jetstream` source for `FastIngest`, `FastIngestOptions`, and
-`FastIngestProgress` shapes.
+### Handling gaps
+
+```ts
+declare const samples: string[]; // sampled metric lines
+
+const fi = await startFastIngest(nc, "metrics.cpu", samples[0], {
+  allowGaps: true,
+});
+
+(async () => {
+  for await (const g of fi.gaps()) {
+    console.warn(`lost samples between batchSeq ${g.lastSeq} and ${g.seq}`);
+  }
+})();
+
+for (let i = 1; i < samples.length; i++) {
+  await fi.add("metrics.cpu", samples[i]);
+}
+await fi.end();
+```
+
+### Keep-alive on slow producers
+
+The server drops a batch that goes 10 seconds without traffic. If the producer
+might pause mid-batch, call `ping()` on a shorter cadence to keep the batch open
+and pull a fresh progress snapshot:
+
+```ts
+setInterval(() => fi.ping().catch(() => {}), 5_000);
+```

--- a/fastingest/README.md
+++ b/fastingest/README.md
@@ -1,5 +1,11 @@
 # fastingest
 
+[![License](https://img.shields.io/badge/Licence-Apache%202.0-blue.svg)](https://github.com/synadia-io/orbit.js/blob/main/LICENSE)
+[![JSR](https://jsr.io/badges/@synadiaorbit/fastingest)](https://jsr.io/@synadiaorbit/fastingest)
+[![JSR Score](https://jsr.io/badges/@synadiaorbit/fastingest/score)](https://jsr.io/@synadiaorbit/fastingest/score)
+[![NPM Version](https://img.shields.io/npm/v/%40synadiaorbit%2Ffastingest)](https://www.npmjs.com/package/@synadiaorbit/fastingest)
+[![NPM Downloads](https://img.shields.io/npm/dt/%40synadiaorbit%2Ffastingest)](https://www.npmjs.com/package/@synadiaorbit/fastingest)
+
 High-throughput batch publish to NATS JetStream. Re-exports the fast-ingest API
 from `@nats-io/jetstream/internal` as a stable orbit surface while the upstream
 API is still considered internal.

--- a/fastingest/deno.json
+++ b/fastingest/deno.json
@@ -1,0 +1,19 @@
+{
+  "name": "@synadiaorbit/fastingest",
+  "version": "0.1.0-0",
+  "exports": {
+    ".": "./src/mod.ts"
+  },
+  "publish": {
+    "exclude": [
+      "./examples"
+    ]
+  },
+  "tasks": {},
+  "imports": {
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@^3.4.0-0",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@^3.4.0-0",
+    "@std/assert": "jsr:@std/assert@^1.0.19"
+  },
+  "nodeModulesDir": "auto"
+}

--- a/fastingest/deno.json
+++ b/fastingest/deno.json
@@ -11,8 +11,10 @@
   },
   "tasks": {},
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@^3.4.0-0",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@^3.4.0-0",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@^3.4.0-2",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@^3.4.0-2",
+    "@nats-io/nst": "jsr:@nats-io/nst@^3.4.0-2",
+    "@nats-io/transport-deno": "jsr:@nats-io/transport-deno@^3.4.0-2",
     "@std/assert": "jsr:@std/assert@^1.0.19"
   },
   "nodeModulesDir": "auto"

--- a/fastingest/package-lock.json
+++ b/fastingest/package-lock.json
@@ -9,32 +9,32 @@
       "version": "0.1.0-0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nats-io/jetstream": "3.4.0-0",
-        "@nats-io/nats-core": "3.4.0-0"
+        "@nats-io/jetstream": "3.4.0-2",
+        "@nats-io/nats-core": "3.4.0-2"
       },
       "devDependencies": {
-        "@types/node": "^24.12.2",
+        "@types/node": "^25.6.2",
         "shx": "^0.4.0",
         "typescript": "^5.9.3"
       }
     },
     "node_modules/@nats-io/jetstream": {
-      "version": "3.4.0-0",
-      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.4.0-0.tgz",
-      "integrity": "sha512-/iinFBfL7eSLjiNkWTg8RzF74xY5azpbhNvJ+1u3CZT1LBwY1WPajpDZoIep7cb63ArxzcrwQ6CXyGz3sg3O/g==",
+      "version": "3.4.0-2",
+      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.4.0-2.tgz",
+      "integrity": "sha512-Sx+9EtFSc0tkMXCGogF978ZUs97etPWrDRZ6LflSTvMRbyy1BNg3liWC/rJkl7n3p7WrHNiwnrU50JFq7bNoOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nats-io/nats-core": "3.4.0-0"
+        "@nats-io/nats-core": "3.4.0-2"
       }
     },
     "node_modules/@nats-io/nats-core": {
-      "version": "3.4.0-0",
-      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.4.0-0.tgz",
-      "integrity": "sha512-cdvABCEiaCakEUbzq6hPowcRGrXBBS9vX8Mp/Cv/HDipQIIhgF6hzttnIq+PGPcGZQ3qmLaunQAd8XK1NCsBhA==",
+      "version": "3.4.0-2",
+      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.4.0-2.tgz",
+      "integrity": "sha512-nZHPVP+In/mdAkAlS5V2qwZuCdbe5hKLNKKSXiwRIX4WVhtIzprV4FZgxYJykTbRoGxrfblrz5xOWPpIDJQX1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nkeys": "2.0.3",
-        "@nats-io/nuid": "2.0.3"
+        "@nats-io/nuid": "3.0.0"
       }
     },
     "node_modules/@nats-io/nkeys": {
@@ -50,12 +50,12 @@
       }
     },
     "node_modules/@nats-io/nuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-2.0.3.tgz",
-      "integrity": "sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-3.0.0.tgz",
+      "integrity": "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">= 18.x"
+        "node": ">= 22.x"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -97,13 +97,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/braces": {
@@ -275,13 +275,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/fastingest/package-lock.json
+++ b/fastingest/package-lock.json
@@ -1,0 +1,708 @@
+{
+  "name": "@synadiaorbit/fastingest",
+  "version": "0.1.0-0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@synadiaorbit/fastingest",
+      "version": "0.1.0-0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/jetstream": "3.4.0-0",
+        "@nats-io/nats-core": "3.4.0-0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.12.2",
+        "shx": "^0.4.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@nats-io/jetstream": {
+      "version": "3.4.0-0",
+      "resolved": "https://registry.npmjs.org/@nats-io/jetstream/-/jetstream-3.4.0-0.tgz",
+      "integrity": "sha512-/iinFBfL7eSLjiNkWTg8RzF74xY5azpbhNvJ+1u3CZT1LBwY1WPajpDZoIep7cb63ArxzcrwQ6CXyGz3sg3O/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nats-core": "3.4.0-0"
+      }
+    },
+    "node_modules/@nats-io/nats-core": {
+      "version": "3.4.0-0",
+      "resolved": "https://registry.npmjs.org/@nats-io/nats-core/-/nats-core-3.4.0-0.tgz",
+      "integrity": "sha512-cdvABCEiaCakEUbzq6hPowcRGrXBBS9vX8Mp/Cv/HDipQIIhgF6hzttnIq+PGPcGZQ3qmLaunQAd8XK1NCsBhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nats-io/nkeys": "2.0.3",
+        "@nats-io/nuid": "2.0.3"
+      }
+    },
+    "node_modules/@nats-io/nkeys": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nkeys/-/nkeys-2.0.3.tgz",
+      "integrity": "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nats-io/nuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nats-io/nuid/-/nuid-2.0.3.tgz",
+      "integrity": "sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18.x"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+      "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/fastingest/package.json
+++ b/fastingest/package.json
@@ -32,11 +32,11 @@
   },
   "description": "fastingest - re-export of jetstream fast ingest batch publish API",
   "dependencies": {
-    "@nats-io/nats-core": "3.4.0-0",
-    "@nats-io/jetstream": "3.4.0-0"
+    "@nats-io/nats-core": "3.4.0-2",
+    "@nats-io/jetstream": "3.4.0-2"
   },
   "devDependencies": {
-    "@types/node": "^24.12.2",
+    "@types/node": "^25.6.2",
     "shx": "^0.4.0",
     "typescript": "^5.9.3"
   }

--- a/fastingest/package.json
+++ b/fastingest/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@synadiaorbit/fastingest",
+  "version": "0.1.0-0",
+  "files": [
+    "lib/",
+    "LICENSE",
+    "README.md"
+  ],
+  "types": "./lib/mod.d.js",
+  "exports": {
+    ".": "./lib/mod.js"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-io/orbit.js.git"
+  },
+  "private": false,
+  "scripts": {
+    "real-clean": "npm run clean && shx rm -Rf ./node_modules",
+    "clean": "shx rm -Rf ./build ./lib",
+    "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
+    "build-cjs": "npm run pre-process && tsc",
+    "build": "npm run build-cjs",
+    "prepack": "npm run build",
+    "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
+    "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
+  },
+  "keywords": [],
+  "author": {
+    "name": "Synadia Communications, Inc."
+  },
+  "description": "fastingest - re-export of jetstream fast ingest batch publish API",
+  "dependencies": {
+    "@nats-io/nats-core": "3.4.0-0",
+    "@nats-io/jetstream": "3.4.0-0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2",
+    "shx": "^0.4.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/fastingest/src/mod.ts
+++ b/fastingest/src/mod.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Synadia Communications, Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { startFastIngest } from "@nats-io/jetstream/internal";
+
+export type {
+  FastIngest,
+  FastIngestOptions,
+  FastIngestProgress,
+} from "@nats-io/jetstream/internal";

--- a/fastingest/tests/basics_test.ts
+++ b/fastingest/tests/basics_test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Synadia Communications, Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { wsconnect } from "@nats-io/nats-core";
+import { jetstreamManager } from "@nats-io/jetstream";
+import {
+  type FastIngest,
+  type FastIngestOptions,
+  type FastIngestProgress,
+  startFastIngest,
+} from "../src/mod.ts";
+import { assertEquals, assertExists } from "@std/assert";
+
+const url = Deno.env.get("NATS_URL") ?? "wss://demo.nats.io:8443";
+
+Deno.test("fastingest - exports", () => {
+  assertEquals(typeof startFastIngest, "function");
+  const _o: Partial<FastIngestOptions> = { allowGaps: false };
+  const _f: FastIngest | null = null;
+  const _p: FastIngestProgress | null = null;
+  assertExists(_o);
+});
+
+Deno.test("fastingest - basics", async () => {
+  const nc = await wsconnect({ servers: url });
+  const jsm = await jetstreamManager(nc);
+
+  try {
+    await jsm.streams.delete("fibatch").catch(() => {});
+    await jsm.streams.add({
+      name: "fibatch",
+      subjects: ["fi"],
+      allow_batched: true,
+    });
+  } catch (err) {
+    const msg = (err as Error).message ?? "";
+    if (msg.includes("allow_batched") || msg.includes("invalid JSON")) {
+      console.warn(`skipping: server does not support allow_batched (${url})`);
+      await nc.close();
+      return;
+    }
+    throw err;
+  }
+
+  const fi = await startFastIngest(nc, "fi", "1", {
+    allowGaps: false,
+    ackInterval: 5,
+  });
+  await fi.add("fi", "2");
+  await fi.add("fi", "3");
+  await fi.add("fi", "4");
+  const ack = await fi.last("fi", "5");
+
+  assertEquals(ack.stream, "fibatch");
+  assertEquals(ack.batch, fi.batch);
+  assertEquals(ack.count, 5);
+
+  await jsm.streams.delete("fibatch").catch(() => {});
+  await nc.close();
+});

--- a/fastingest/tests/basics_test.ts
+++ b/fastingest/tests/basics_test.ts
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import { wsconnect } from "@nats-io/nats-core";
+import "./connect.ts";
+
 import { jetstreamManager } from "@nats-io/jetstream";
 import {
   type FastIngest,
@@ -22,8 +23,7 @@ import {
   startFastIngest,
 } from "../src/mod.ts";
 import { assertEquals, assertExists } from "@std/assert";
-
-const url = Deno.env.get("NATS_URL") ?? "wss://demo.nats.io:8443";
+import { cleanup, jetstreamServerConf, notCompatible, setup } from "@nats-io/nst";
 
 Deno.test("fastingest - exports", () => {
   assertEquals(typeof startFastIngest, "function");
@@ -34,25 +34,17 @@ Deno.test("fastingest - exports", () => {
 });
 
 Deno.test("fastingest - basics", async () => {
-  const nc = await wsconnect({ servers: url });
-  const jsm = await jetstreamManager(nc);
-
-  try {
-    await jsm.streams.delete("fibatch").catch(() => {});
-    await jsm.streams.add({
-      name: "fibatch",
-      subjects: ["fi"],
-      allow_batched: true,
-    });
-  } catch (err) {
-    const msg = (err as Error).message ?? "";
-    if (msg.includes("allow_batched") || msg.includes("invalid JSON")) {
-      console.warn(`skipping: server does not support allow_batched (${url})`);
-      await nc.close();
-      return;
-    }
-    throw err;
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
   }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({
+    name: "fibatch",
+    subjects: ["fi"],
+    allow_batched: true,
+  });
 
   const fi = await startFastIngest(nc, "fi", "1", {
     allowGaps: false,
@@ -67,6 +59,5 @@ Deno.test("fastingest - basics", async () => {
   assertEquals(ack.batch, fi.batch);
   assertEquals(ack.count, 5);
 
-  await jsm.streams.delete("fibatch").catch(() => {});
-  await nc.close();
+  await cleanup(ns, nc);
 });

--- a/fastingest/tests/basics_test.ts
+++ b/fastingest/tests/basics_test.ts
@@ -16,25 +16,19 @@
 import "./connect.ts";
 
 import { jetstreamManager } from "@nats-io/jetstream";
-import {
-  type FastIngest,
-  type FastIngestOptions,
-  type FastIngestProgress,
-  startFastIngest,
-} from "../src/mod.ts";
+import { type FastIngestOptions, startFastIngest } from "../src/mod.ts";
 import { assertEquals, assertExists } from "@std/assert";
-import { cleanup, jetstreamServerConf, notCompatible, setup } from "@nats-io/nst";
+import { jetstreamServerConf, notCompatible, setup } from "@nats-io/nst";
 
 Deno.test("fastingest - exports", () => {
   assertEquals(typeof startFastIngest, "function");
   const _o: Partial<FastIngestOptions> = { allowGaps: false };
-  const _f: FastIngest | null = null;
-  const _p: FastIngestProgress | null = null;
   assertExists(_o);
 });
 
 Deno.test("fastingest - basics", async () => {
-  const { ns, nc } = await setup(jetstreamServerConf({}));
+  await using ctx = await setup(jetstreamServerConf({}));
+  const { ns, nc } = ctx;
   if (await notCompatible(ns, nc, "2.14.0")) {
     return;
   }
@@ -58,6 +52,5 @@ Deno.test("fastingest - basics", async () => {
   assertEquals(ack.stream, "fibatch");
   assertEquals(ack.batch, fi.batch);
   assertEquals(ack.count, 5);
-
-  await cleanup(ns, nc);
+  assertEquals(ack.seq, 5);
 });

--- a/fastingest/tests/connect.ts
+++ b/fastingest/tests/connect.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Synadia Communications, Inc
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { connect } from "@nats-io/transport-deno";
+import { registerConnect } from "@nats-io/nst";
+
+registerConnect(connect);

--- a/fastingest/tsconfig.json
+++ b/fastingest/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "outDir": "./lib/",
+    "moduleResolution": "nodenext",
+    "sourceMap": true,
+    "declaration": true,
+    "allowJs": true,
+    "removeComments": false,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "./build/src/**/*"
+  ]
+}

--- a/messagepipeline/package-lock.json
+++ b/messagepipeline/package-lock.json
@@ -13,9 +13,9 @@
         "@nats-io/services": "3.3.1"
       },
       "devDependencies": {
-        "@types/node": "^24.5.0",
+        "@types/node": "^25.6.2",
         "shx": "^0.4.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@nats-io/nats-core": {
@@ -97,13 +97,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/braces": {
@@ -275,13 +275,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/messagepipeline/package.json
+++ b/messagepipeline/package.json
@@ -36,7 +36,7 @@
     "@nats-io/services": "3.3.1"
   },
   "devDependencies": {
-    "@types/node": "^24.12.2",
+    "@types/node": "^25.6.2",
     "shx": "^0.4.0",
     "typescript": "^5.9.3"
   }

--- a/muxsub/package-lock.json
+++ b/muxsub/package-lock.json
@@ -12,9 +12,9 @@
         "@nats-io/nats-core": "3.3.1"
       },
       "devDependencies": {
-        "@types/node": "^24.5.0",
+        "@types/node": "^25.6.2",
         "shx": "^0.4.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@nats-io/nats-core": {
@@ -87,13 +87,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/braces": {
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/muxsub/package.json
+++ b/muxsub/package.json
@@ -35,7 +35,7 @@
     "@nats-io/nats-core": "3.3.1"
   },
   "devDependencies": {
-    "@types/node": "^24.12.2",
+    "@types/node": "^25.6.2",
     "shx": "^0.4.0",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
## Summary
- new orbit module `fastingest` re-exports `startFastIngest`, `FastIngest`, `FastIngestOptions`, `FastIngestProgress` from `@nats-io/jetstream/internal`
- requires NATS server 2.14.0+ + stream w/ `allow_batched: true`
- deps pinned to `3.4.0-2` (latest prerelease)
- mirrors counters/muxsub layout (package.json, deno.json, tsconfig, src/mod.ts, tests)
- integration test uses `@nats-io/nst@^3.4.0-2` (published peer test tooling) — spawns a real `nats-server` via `setup`/`cleanup`/`notCompatible`. Avoids vendoring test_helpers
- ci.yml installs `nats-server` via `aricart/install-binary@v2.0.0`, gated to `matrix.module == 'fastingest'`
- README.md utilities table updated

## Drive-by infra bumps (separate commit)
- `@types/node` ^24.12.2 -> ^25.6.2 across all modules (matches nats.js)
- release.yml `node-version` 24.x -> 25.x
- ci.yml + release.yml `deno-version` 2.6.x -> 2.7.x
- lockfiles regenerated

## Test plan
- [x] deno test passes locally for all 4 modules (nats-server 2.14.0-RC.3 in path)
- [x] npm run build passes locally for all 4 modules
- [ ] CI matrix runs fastingest tests w/ install-binary action
- [ ] dry-run release dispatch for fastingest after merge